### PR TITLE
Horizontal scrollbar in <pre> only when necessary.

### DIFF
--- a/site/styles/index.scss
+++ b/site/styles/index.scss
@@ -10,7 +10,7 @@ pre {
   padding: 1.3em;
   background-color: #f9f6dc;
   font-size: .75rem;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 p > code {


### PR DESCRIPTION
Changed the `overflow-x` property to avoid `<pre>`tags showing that ugly empty horizontal scrollbar when its content is not wider.

![svgi](https://cloud.githubusercontent.com/assets/7225802/26774782/2fc0df26-49d2-11e7-83eb-d9e2284d81cc.gif)

This change has been tested in macOS  Chrome 58.0.3029.110, Firefox 53.0.3, Safari 10.1.1 and Opera 45.0.2552.888

PS: Super great project @Angelmmiguel !