### PR TITLE
Add pretty printing for file size

### DIFF
--- a/lib/svg.js
+++ b/lib/svg.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs');
 // External
 const xml2js = require('xml2js');
+const filesize = require('filesize');
 // Project
 const Node = require('./node');
 const {allCategories, allTypes} = require('./utils/nodeTypes');
@@ -50,7 +51,7 @@ class SVG extends Node {
       // Store data
       this.filePath = path.resolve(filePath);
       this.fileName = path.basename(filePath);
-      this.fileSize = fileStats.size;
+      this.fileSize = filesize(fileStats.size);
       this.fileInfo = true;
     } else {
       this.fileInfo = false;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "cli-table": "^0.3.1",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
+    "filesize": "^3.5.10",
     "js-yaml": "^3.8.4",
     "xml2js": "^0.4.17"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,6 +855,10 @@ fileset@^2.0.2:
     glob "^7.0.3"
     minimatch "^3.0.3"
 
+filesize@^3.5.10:
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.10.tgz#fc8fa23ddb4ef9e5e0ab6e1e64f679a24a56761f"
+
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"


### PR DESCRIPTION
Fixes #4

Added filesize package and line to convert the number of bytes to a more human readable form. If you would prefer to not add another dependency, let me know and I'd be willing to go with a different approach, but this is the most straightforward solution