### PR TITLE
[#38] chore: prepare release 1.1.1 and ignore multiple files on the final bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+# Ignore all files not related with the final build
+.github
+coverage
+node_modules
+scripts
+site
+test
+.all-contributorsrc
+.eslintrc
+.gitignore
+.travis.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svgi",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "svgi",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ascii-tree": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svgi",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An SVG inspector tool",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Update the version to 1.1.1 and remove many files from teh final bundle using the `.npmignore`. After adding the ignore file, these are the files added to the bundle:

```
npm publish --dry-run

npm notice 
npm notice 📦  svgi@1.1.1
npm notice === Tarball Contents ===
npm notice 11.5kB LICENSE
npm notice 11.8kB README.md
npm notice 3.2kB  bin/index.js
npm notice 66B    index.js
npm notice 4.9kB  lib/formatters/human.js
npm notice 734B   lib/formatters/json.js
npm notice 769B   lib/formatters/yaml.js
npm notice 3.4kB  lib/node.js
npm notice 3.0kB  lib/svg.js
npm notice 4.2kB  lib/utils/nodeTypes.js
npm notice 1.2kB  package.json
npm notice === Tarball Details ===
npm notice name:          svgi
npm notice version:       1.1.1
npm notice filename:      svgi-1.1.1.tgz
npm notice package size:  13.0 kB
npm notice unpacked size: 44.7 kB
npm notice shasum:        51ef36da70c9ed8f471ba7f1b96fd0f87d3434cc
npm notice integrity:     sha512-P0NWigexMFRZS[...]hwUhlnJ+2uUxg==
npm notice total files:   11
npm notice
```

Closes #38