### PR TITLE
[#40] feat: stop providing file information in the core library

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -2,7 +2,9 @@
 
 // Requires (Native)
 const fs = require('fs');
+const path = require('path');
 // External
+const filesize = require('filesize');
 const { program, Option } = require('commander');
 const colors = require('colors/safe');
 // Project
@@ -62,22 +64,33 @@ const app = (filePath, opts) => {
 
   dataPromise
     .then((data) => {
-        let svg = new SVG(data, filePath);
+        let svg = new SVG(data);
         let output;
+        let file;
 
         if(filePath && !process.stdin.isTTY) {
           commander.dualInputs = true;
         };
 
+        if(filePath) {
+          let fileStats = fs.statSync(__dirname, filePath);
+
+          file = {
+            name: path.resolve(filePath),
+            path: path.basename(filePath),
+            size: filesize(fileStats.size)
+          }
+        }
+
         switch (opts.output) {
           case 'json':
-            output = jsonFormatter(svg, opts);
+            output = jsonFormatter(svg, file, opts);
             break;
           case 'yaml':
-            output = yamlFormatter(svg, opts);
+            output = yamlFormatter(svg, file, opts);
             break;
           default:
-            output = humanFormatter(svg, opts);
+            output = humanFormatter(svg, file, opts);
         }
 
         // Display the output

--- a/lib/formatters/human.js
+++ b/lib/formatters/human.js
@@ -103,11 +103,12 @@ const treeLegend = () => {
  * Format the result of the CLI.
  *
  * @param {SVG} svg SVG Instance
+ * @param {object} file Provides information about the file. Undefined for STDIN
  * @param {object} options Options for the formatter from the ARGV
  * @return {string} Information of the SVG as a string ready for
  *                  display in the console.
  */
-const format = (svg, options) => {
+const format = (svg, file, options) => {
   let output = '';
   let report = svg.report(options.allStats);
   let all = (!options.tree && !options.stats && !options.basic);
@@ -120,11 +121,11 @@ const format = (svg, options) => {
   if (all || options.basic) {
     output += title('Basic information');
     let table = new Table();
-    if (report.file && !options.dualInputs) {
+    if (file && !options.dualInputs) {
       table.push(
-        ['Name', report.file.name],
-        ['Path', report.file.path],
-        ['Size', report.file.size]
+        ['Name', file.name],
+        ['Path', file.path],
+        ['Size', file.size]
       );
     } else {
       table.push(

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -2,16 +2,17 @@
  * Format the result of the CLI.
  *
  * @param {SVG} svg SVG Instance
+ * @param {object} file Provides information about the file. Undefined for STDIN
  * @param {object} options Options for the formatter from the ARGV
  * @return {String} JSON object as a string ready for display in the console.
  */
-const format = (svg, options) => {
+const format = (svg, file, options) => {
   let output = {};
   let report = svg.report(options.allStats);
   let all = (!options.tree && !options.stats && !options.basic);
 
   if (all || options.basic) {
-    output.file = report.file ? report.file : {
+    output.file = file ? file : {
       name: 'stdin',
     };
   }

--- a/lib/formatters/yaml.js
+++ b/lib/formatters/yaml.js
@@ -5,16 +5,17 @@ const YAML = require('js-yaml');
  * Format the result of the CLI.
  *
  * @param {SVG} svg SVG Instance
+ * @param {object} file Provides information about the file. Undefined for STDIN
  * @param {object} options Options for the formatter from the ARGV
  * @return {String} YAML object as a string ready for display in the console.
  */
-const format = (svg, options) => {
+const format = (svg, file, options) => {
   let output = {};
   let report = svg.report(options.allStats);
   let all = (!options.tree && !options.stats && !options.basic);
 
   if (all || options.basic) {
-    output.file = report.file ? report.file : {
+    output.file = file ? file : {
       name: 'stdin',
     };
   }

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,9 +1,5 @@
-// Native
-const path = require('path');
-const fs = require('fs');
 // External
 const xml2js = require('xml2js');
-const filesize = require('filesize');
 // Project
 const Node = require('./node');
 const {allCategories, allTypes} = require('./utils/nodeTypes');
@@ -19,9 +15,8 @@ class SVG extends Node {
    * Data of the node.
    *
    * @param {string} svgString A string with the content of the SVG file
-   * @param {string} filePath The path of the current file
    */
-  constructor(svgString, filePath = '') {
+  constructor(svgString) {
     // Output
     let error;
     let data;
@@ -43,19 +38,6 @@ class SVG extends Node {
 
     // Base properties
     super('svg', data.svg);
-
-    if (filePath !== '') {
-      // Store additional data
-      let fileStats = fs.statSync(__dirname, filePath);
-
-      // Store data
-      this.filePath = path.resolve(filePath);
-      this.fileName = path.basename(filePath);
-      this.fileSize = filesize(fileStats.size);
-      this.fileInfo = true;
-    } else {
-      this.fileInfo = false;
-    }
   }
 
   /**
@@ -104,15 +86,6 @@ class SVG extends Node {
       stats: this.getStats(includeAll),
       nodes: super.report(),
     };
-
-    // Only add the file information if it's available
-    if (this.fileInfo) {
-      result.file = {
-        name: this.fileName,
-        path: this.filePath,
-        size: this.fileSize,
-      };
-    }
 
     return result;
   }


### PR DESCRIPTION
Stop providing the file information from the core library. Instead, let's retrieve this information in the CLI library directly. With this small change, `fs`, `path` and `filesize` is not required in the core library anymore.

Closes #40 