### PR TITLE
fix: configure the XML parser to maintain child order

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -18,23 +18,17 @@ class Node {
     this.type = type;
     this.properties = data.$ || {};
     this.parent = parent;
-    this.text = '';
+    this.text = data._ || '';
     this.category = typeCategory(type);
     // Create the array of children
     this.children = [];
 
-    Object.keys(data).filter((el) => el !== '$').forEach((childType) => {
-      // Iterate over child
-      if (typeof data[childType] === 'string') {
-        this.text = data[childType];
-      } else if (Array.isArray(data[childType])) {
-        data[childType].forEach((child) => {
-          this.children.push(new Node(childType, child, this));
-        }, this);
-      } else {
-        throw new Error(`Unknown content for ${this.type}: ${data[childType]}`);
-      }
-    }, this);
+    // Iterate over children
+    if (data.$$ != null && data.$$.length > 0) {
+      data.$$.forEach((child) => {
+        this.children.push(new Node(child['#name'], child, this));
+      }, this);
+    }
   }
 
   /**

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -5,7 +5,10 @@ const Node = require('./node');
 const {allCategories, allTypes} = require('./utils/nodeTypes');
 
 // Parser
-const parser = new xml2js.Parser();
+const parser = new xml2js.Parser({ 
+  preserveChildrenOrder: true, 
+  explicitChildren: true 
+});
 
 /**
  * Class that represent a node in the tree of the SVG

--- a/test/ordering.test.js
+++ b/test/ordering.test.js
@@ -1,0 +1,18 @@
+import { assert, expect, test } from "vitest";
+import SVG from "../lib/svg";
+
+// Test data
+const testSVG = `<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="80" height="80" viewBox="0 0 80 80">
+  <rect x="0" y="0" width="48" height="48"/>
+  <circle cx="24" cy="24" r="24"/>
+  <rect x="16" y="16" width="16" height="16" />
+</svg>`;
+
+test("SVG parses SVG file as a string and maintain the ordering of the children nodes", () => {
+  const svg = new SVG(testSVG);
+  const report = svg.report();
+
+  expect(report.nodes.children[0].type).toBe("rect");
+  expect(report.nodes.children[1].type).toBe("circle");
+  expect(report.nodes.children[2].type).toBe("rect");
+});


### PR DESCRIPTION
To fix this issue, I configured the XML parser with the following options:

```javascript
// Parser
const parser = new xml2js.Parser({ 
  preserveChildrenOrder: true, 
  explicitChildren: true 
});
```

This configuration adds a `$$` property to the nodes that represents an array of the children in the right order. I added a test to check it.

It closes #46 